### PR TITLE
Add wrapping breaks

### DIFF
--- a/src/pp.ml
+++ b/src/pp.ml
@@ -17,8 +17,7 @@ type +'a t =
   | Hovbox of int * 'a t
   | Verbatim of string
   | Char of char
-  | Break of int * int
-  | Custom_break of (string * int * string) * (string * int * string)
+  | Break of (string * int * string) * (string * int * string)
   | Newline
   | Text of string
   | Tag of 'a * 'a t
@@ -33,8 +32,7 @@ let rec map_tags t ~f =
   | Hbox t -> Hbox (map_tags t ~f)
   | Hvbox (indent, t) -> Hvbox (indent, map_tags t ~f)
   | Hovbox (indent, t) -> Hovbox (indent, map_tags t ~f)
-  | (Verbatim _ | Char _ | Break _ | Custom_break _ | Newline | Text _) as t ->
-    t
+  | (Verbatim _ | Char _ | Break _ | Newline | Text _) as t -> t
   | Tag (tag, t) -> Tag (f tag, map_tags t ~f)
 
 let rec filter_map_tags t ~f =
@@ -48,8 +46,7 @@ let rec filter_map_tags t ~f =
   | Hbox t -> Hbox (filter_map_tags t ~f)
   | Hvbox (indent, t) -> Hvbox (indent, filter_map_tags t ~f)
   | Hovbox (indent, t) -> Hovbox (indent, filter_map_tags t ~f)
-  | (Verbatim _ | Char _ | Break _ | Custom_break _ | Newline | Text _) as t ->
-    t
+  | (Verbatim _ | Char _ | Break _ | Newline | Text _) as t -> t
   | Tag (tag, t) -> (
     let t = filter_map_tags t ~f in
     match f tag with
@@ -93,8 +90,7 @@ module Render = struct
       pp_close_box ppf ()
     | Verbatim x -> pp_print_string ppf x
     | Char x -> pp_print_char ppf x
-    | Break (nspaces, shift) -> pp_print_break ppf nspaces shift
-    | Custom_break (fits, breaks) -> pp_print_custom_break ppf ~fits ~breaks
+    | Break (fits, breaks) -> pp_print_custom_break ppf ~fits ~breaks
     | Newline -> pp_force_newline ppf ()
     | Text s -> pp_print_text ppf s
     | Tag (tag, t) -> tag_handler ppf tag t
@@ -140,13 +136,14 @@ let verbatim x = Verbatim x
 
 let char x = Char x
 
-let break ~nspaces ~shift = Break (nspaces, shift)
+let custom_break ~fits ~breaks = Break (fits, breaks)
 
-let custom_break ~fits ~breaks = Custom_break (fits, breaks)
+let break ~nspaces ~shift =
+  custom_break ~fits:("", nspaces, "") ~breaks:("", shift, "")
 
-let space = Break (1, 0)
+let space = break ~nspaces:1 ~shift:0
 
-let cut = Break (0, 0)
+let cut = break ~nspaces:0 ~shift:0
 
 let newline = Newline
 

--- a/src/pp.mli
+++ b/src/pp.mli
@@ -43,15 +43,6 @@ val textf : ('a, unit, string, _ t) format4 -> 'a
     or "x\n<indentation>y". *)
 val space : _ t
 
-(** [wrapping_space] is the wrapping alternative of [space], it instructs the
-    pretty-printing algorithm that the line may be broken at this point. If the
-    algorithm decides not to break the line, a single space will be printed
-    instead. If the line breaks, " \\" is printed before the linebreak.
-
-    So for instance [verbatim "x" ++ wrapping_space ++ verbatim "y"] might
-    produce "x y" or "x \\\n<indentation>y". *)
-val wrapping_space : _ t
-
 (** [cut] instructs the pretty-printing algorithm that the line may be broken at
     this point. If the algorithm decides not to break the line, nothing is
     printed instead.
@@ -67,13 +58,15 @@ val cut : _ t
     which case the indentation will be reduced. *)
 val break : nspaces:int -> shift:int -> _ t
 
-(** [wrapping_break] is the wrapping alternative of [break], and a
-    generalisation of [wrapping_space]. It also instructs the pretty-printing
-    algorithm that the line may be broken at this point. If it ends up being
-    broken, " \\" is printed before the linebreak and [shift] will be added to
-    the indentation level, otherwise [nspaces] spaces will be printed. [shift]
-    can be negative, in which case the indentation will be reduced. *)
-val wrapping_break : nspaces:int -> shift:int -> _ t
+(** [custom_break ~fits:(a, b, c) ~breaks:(x, y, z)] is a generalisation of
+    [break]. It also instructs the pretty-printing algorithm that the line may
+    be broken at this point. If it ends up being broken, [x] is printed, the
+    line breaks, [y] will be added to the indentation level and [z] is printed,
+    otherwise [a] will be printed, [b] spaces are printed and then [c] is
+    printed. The indentation [y] can be negative, in which case the indentation
+    will be reduced. *)
+val custom_break :
+  fits:string * int * string -> breaks:string * int * string -> _ t
 
 (** Force a newline to be printed *)
 val newline : _ t

--- a/src/pp.mli
+++ b/src/pp.mli
@@ -43,6 +43,15 @@ val textf : ('a, unit, string, _ t) format4 -> 'a
     or "x\n<indentation>y". *)
 val space : _ t
 
+(** [wrapping_space] is the wrapping alternative of [space], it instructs the
+    pretty-printing algorithm that the line may be broken at this point. If the
+    algorithm decides not to break the line, a single space will be printed
+    instead. If the line breaks, " \\" is printed before the linebreak.
+
+    So for instance [verbatim "x" ++ wrapping_space ++ verbatim "y"] might
+    produce "x y" or "x \\\n<indentation>y". *)
+val wrapping_space : _ t
+
 (** [cut] instructs the pretty-printing algorithm that the line may be broken at
     this point. If the algorithm decides not to break the line, nothing is
     printed instead.
@@ -57,6 +66,14 @@ val cut : _ t
     otherwise [nspaces] spaces will be printed. [shift] can be negative, in
     which case the indentation will be reduced. *)
 val break : nspaces:int -> shift:int -> _ t
+
+(** [wrapping_break] is the wrapping alternative of [break], and a
+    generalisation of [wrapping_space]. It also instructs the pretty-printing
+    algorithm that the line may be broken at this point. If it ends up being
+    broken, " \\" is printed before the linebreak and [shift] will be added to
+    the indentation level, otherwise [nspaces] spaces will be printed. [shift]
+    can be negative, in which case the indentation will be reduced. *)
+val wrapping_break : nspaces:int -> shift:int -> _ t
 
 (** Force a newline to be printed *)
 val newline : _ t

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -195,3 +195,26 @@ let%expect_test _ =
       - scream loudly at your computer
       - take a break from your keyboard
       - clear your head and try again |}]
+
+(* Wrap the formatted lines *)
+let%expect_test _ =
+  print
+    (Pp.hovbox
+       ( Array.make 50 (Pp.char 'x')
+       |> Array.to_list
+       |> Pp.concat ~sep:Pp.wrapping_space ));
+  [%expect
+    {|
+x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x \
+x x x x x x x x x x x x
+|}];
+  print
+    (Pp.hovbox ~indent:2
+       ( Array.make 50 (Pp.char 'x')
+       |> Array.to_list
+       |> Pp.concat ~sep:(Pp.wrapping_break ~nspaces:2 ~shift:(-1)) ));
+  [%expect
+    {|
+x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x \
+ x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x
+|}]

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -199,20 +199,11 @@ let%expect_test _ =
 (* Wrap the formatted lines *)
 let%expect_test _ =
   print
-    (Pp.hovbox
-       ( Array.make 50 (Pp.char 'x')
-       |> Array.to_list
-       |> Pp.concat ~sep:Pp.wrapping_space ));
-  [%expect
-    {|
-x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x \
-x x x x x x x x x x x x
-|}];
-  print
     (Pp.hovbox ~indent:2
        ( Array.make 50 (Pp.char 'x')
        |> Array.to_list
-       |> Pp.concat ~sep:(Pp.wrapping_break ~nspaces:2 ~shift:(-1)) ));
+       |> Pp.concat
+            ~sep:(Pp.custom_break ~fits:("", 2, "") ~breaks:(" \\", -1, "")) ));
   [%expect
     {|
 x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x \


### PR DESCRIPTION
Hi,
This is an upstreaming of the changes done for https://github.com/ocaml/dune/pull/3616

I chose to have something quite specific as `Wrapping_break` instead of having something as generic as `Custom_break of (string * int * string) * (string * int * string)` that is less likely to be used, but if you already see usecases for this in dune I can change it.