### PR TITLE
add Pp.verbatimf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Unreleased
 ----------
 
-- Add `Pp.verbatimf`. (@mbarbin)
+- Add `Pp.verbatimf`. (#18, @mbarbin)
 
 - Remove `of_fmt` constructor. (#17, @Alizter)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- Add `Pp.verbatimf`. (@mbarbin)
+
 - Remove `of_fmt` constructor. (#17, @Alizter)
 
 1.2.0

--- a/src/pp.ml
+++ b/src/pp.ml
@@ -134,6 +134,7 @@ let hbox t = Hbox t
 let hvbox ?(indent = 0) t = Hvbox (indent, t)
 let hovbox ?(indent = 0) t = Hovbox (indent, t)
 let verbatim x = Verbatim x
+let verbatimf fmt = Printf.ksprintf verbatim fmt
 let char x = Char x
 let custom_break ~fits ~breaks = Break (fits, breaks)
 

--- a/src/pp.mli
+++ b/src/pp.mli
@@ -29,6 +29,9 @@ val concat_mapi : ?sep:'tag t -> 'a list -> f:(int -> 'a -> 'tag t) -> 'tag t
 (** An indivisible block of text. *)
 val verbatim : string -> 'tag t
 
+(** Same as [verbatim] but take a format string as argument. *)
+val verbatimf : ('a, unit, string, 'tag t) format4 -> 'a
+
 (** A single character. *)
 val char : char -> 'tag t
 

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -102,6 +102,10 @@ Hello x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
   x x x x x x x x x x x x
 |}]
 
+let%expect_test "verbatimf" =
+  print (Pp.verbatimf "ident%d" 42);
+  [%expect {| ident42 |}]
+
 (* Difference between box and hovbox *)
 let%expect_test _ =
   let pp f = f (xs 50 ++ Pp.break ~nspaces:2 ~shift:(-1) ++ xs 10) in


### PR DESCRIPTION
Follow the same naming scheme as existing functions textf and paragraphf.

This function is meant to allow simplifying occurrences of the pattern `Pp.verbatim (Printf.sprintf ...)`.

As a motivating example, you may refer to [this file](https://github.com/mbarbin/bopkit/blob/main/lib/bopkit_to_c/src/c_code.ml) (although it is taken from a toy project).

Thank you for pp!