### PR TITLE
fix: type of Pp.paragraphf and add changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Unreleased
 
 - Add `Pp.verbatimf`. (#18, @mbarbin)
 
+- Add `Pp.paragraph` and `Pp.paragraphf` (#19, @Alizter)
+
 - Remove `of_fmt` constructor. (#17, @Alizter)
 
 1.2.0

--- a/src/pp.ml
+++ b/src/pp.ml
@@ -29,6 +29,8 @@ include Ast
 let of_ast = Fun.id
 let to_ast = Fun.id
 
+type ('a, 'tag) format_string = ('a, unit, string, 'tag t) format4
+
 let rec map_tags t ~f =
   match t with
   | Nop -> Nop
@@ -145,10 +147,10 @@ let space = break ~nspaces:1 ~shift:0
 let cut = break ~nspaces:0 ~shift:0
 let newline = Newline
 let text s = Text s
-let textf fmt = Printf.ksprintf text fmt
+let textf (fmt : ('a, 'tag) format_string) = Printf.ksprintf text fmt
 let tag tag t = Tag (tag, t)
 let paragraph s = hovbox (text s)
-let paragraphf fmt = hovbox (textf fmt)
+let paragraphf (fmt : ('a, 'tag) format_string) = Printf.ksprintf paragraph fmt
 
 let enumerate l ~f =
   vbox

--- a/src/pp.mli
+++ b/src/pp.mli
@@ -155,7 +155,7 @@ val paragraph : string -> 'tag t
 
 (** [paragraphf s] is [textf s] followed by a [hovbox]. The [textf] version of
     [paragraph]. *)
-val paragraphf : ('tag t, unit, string, 'b t) format4 -> 'tag t
+val paragraphf : ('a, unit, string, 'tag t) format4 -> 'a
 
 (** [enumerate l ~f] produces an enumeration of the form:
 

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -327,3 +327,6 @@ let%expect_test "paragraph" =
     -< box + text >-----------
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum euismod,
     nisl eget aliquam ultricies. |}]
+
+let%expect_test "paragraphf" = print (Pp.paragraphf "Hello World%s" "!");
+  [%expect {| Hello World! |}]


### PR DESCRIPTION
We define the format string internally so that it can be enforced somewhat.
