### PR TITLE
Update make release for dune-release.2.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+- Update `make release` for `dune-release.2.0.0` (#22, @mbarbin).
+
 2.0.0
 -----
 

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ clean:
 
 release:
 	dune-release tag
-	dune-release distrib --skip-build --skip-lint --skip-tests -n pp
-# See https://github.com/ocamllabs/dune-release/issues/206
-	DUNE_RELEASE_DELEGATE=github-dune-release-delegate dune-release publish distrib --verbose -n pp
-	dune-release opam pkg -n pp
-	dune-release opam submit -n pp
+	dune-release distrib --skip-build --skip-lint --skip-tests
+	dune-release publish distrib --verbose
+	dune-release publish doc --verbose
+	dune-release opam pkg
+	dune-release opam submit
 
 .PHONY: default install uninstall reinstall clean test


### PR DESCRIPTION
While cutting the release 2.0.0 I noticed a few things that needs updating in the `make release` script.

1. The option `-n` was renamed. I removed it, `dune-release` is now able to determine the package name from the opam file found at the root;
2. The work around for delegates is no longer necessary, I removed it;
3. Seeing that we do publish the doc in the `gh-pages` branch, I added the corresponding entry (`publish doc`)

As it stands, I believe the release sequence is very close to what `dune-release` does by default when invoked without arguments, but keeping the entries as a sequence allows to trouble shoot if a step fails, doing some sanity checks along the way, etc.